### PR TITLE
Downgraded C++ version from C++20 to C++17 due to abseil-cpp

### DIFF
--- a/cmake/init_target.cmake
+++ b/cmake/init_target.cmake
@@ -5,12 +5,12 @@
 # https://github.com/desktop-app/legal/blob/master/LEGAL
 
 function(init_target target_name) # init_target(my_target folder_name)
-    if (WIN32)
-        target_compile_features(${target_name} PUBLIC cxx_std_17)
-    elseif (APPLE)
+    if (APPLE)
         target_compile_features(${target_name} PUBLIC cxx_std_14)
     else()
-        target_compile_features(${target_name} PUBLIC cxx_std_20)
+        # C++20 is not supported by bundled abseil-cpp yet:
+        # https://github.com/abseil/abseil-cpp/issues/722
+        target_compile_features(${target_name} PUBLIC cxx_std_17)
     endif()
     if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         set_target_properties(${target_name} PROPERTIES


### PR DESCRIPTION
Downgraded C++ version from C++20 to C++17 as a workaround to abseil-cpp upstream issue.

See also: https://github.com/abseil/abseil-cpp/issues/722

This will fix build under GCC 10+.

Closes #4.