### PR TITLE
Fix libpffft build failure on ARM platforms that don't support NEON.

### DIFF
--- a/cmake/libpffft.cmake
+++ b/cmake/libpffft.cmake
@@ -15,6 +15,13 @@ PRIVATE
     _USE_MATH_DEFINES
 )
 
+if ((is_arm OR is_aarch64) AND (NOT arm_use_neon))
+    target_compile_definitions(libpffft
+    PRIVATE
+        PFFFT_SIMD_DISABLE
+    )
+endif()
+
 target_include_directories(libpffft
 PUBLIC
     ${libpffft_loc}


### PR DESCRIPTION
Currently, libpffft always expects NEON on ARM platforms.  This behavior can be changed by defining the PFFFT_SIMD_DISABLE compile-time macro when building on ARM but NEON is not available, which is what this pull request does.

This pull request depends on https://github.com/desktop-app/tg_owt/pull/19 for architecture detection.