### PR TITLE
Add support for building on ARM (32-bit and 64-bit), with or without NEON SIMD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,7 +662,6 @@ PRIVATE
     modules/audio_coding/codecs/isac/empty.cc
     modules/audio_coding/codecs/isac/fix/source/audio_decoder_isacfix.cc
     modules/audio_coding/codecs/isac/fix/source/audio_encoder_isacfix.cc
-    modules/audio_coding/codecs/isac/fix/source/isacfix.c
     modules/audio_coding/codecs/isac/fix/source/arith_routines.c
     modules/audio_coding/codecs/isac/fix/source/arith_routines_hist.c
     modules/audio_coding/codecs/isac/fix/source/arith_routines_logist.c
@@ -672,13 +671,18 @@ PRIVATE
     modules/audio_coding/codecs/isac/fix/source/decode_plc.c
     modules/audio_coding/codecs/isac/fix/source/encode.c
     modules/audio_coding/codecs/isac/fix/source/entropy_coding.c
+    modules/audio_coding/codecs/isac/fix/source/entropy_coding_neon.c
+    modules/audio_coding/codecs/isac/fix/source/filterbanks_neon.c
+    modules/audio_coding/codecs/isac/fix/source/filters_neon.c
     modules/audio_coding/codecs/isac/fix/source/fft.c
     modules/audio_coding/codecs/isac/fix/source/filterbank_tables.c
     modules/audio_coding/codecs/isac/fix/source/filterbanks.c
     modules/audio_coding/codecs/isac/fix/source/filters.c
     modules/audio_coding/codecs/isac/fix/source/initialize.c
+    modules/audio_coding/codecs/isac/fix/source/isacfix.c
     modules/audio_coding/codecs/isac/fix/source/lattice.c
     modules/audio_coding/codecs/isac/fix/source/lattice_c.c
+    modules/audio_coding/codecs/isac/fix/source/lattice_neon.c
     modules/audio_coding/codecs/isac/fix/source/lpc_masking_model.c
     modules/audio_coding/codecs/isac/fix/source/lpc_tables.c
     modules/audio_coding/codecs/isac/fix/source/pitch_estimator.c
@@ -689,6 +693,7 @@ PRIVATE
     modules/audio_coding/codecs/isac/fix/source/pitch_lag_tables.c
     modules/audio_coding/codecs/isac/fix/source/spectrum_ar_model_tables.c
     modules/audio_coding/codecs/isac/fix/source/transform.c
+    modules/audio_coding/codecs/isac/fix/source/transform_neon.c
     modules/audio_coding/codecs/isac/fix/source/transform_tables.c
     modules/audio_coding/codecs/isac/main/source/audio_decoder_isac.cc
     modules/audio_coding/codecs/isac/main/source/audio_encoder_isac.cc
@@ -934,6 +939,7 @@ PRIVATE
     modules/audio_processing/aec_dump/null_aec_dump_factory.cc
     modules/audio_processing/aecm/aecm_core.cc
     modules/audio_processing/aecm/aecm_core_c.cc
+    modules/audio_processing/aecm/aecm_core_neon.cc
     modules/audio_processing/aecm/echo_control_mobile.cc
     modules/audio_processing/agc/agc.cc
     modules/audio_processing/agc/agc_manager_direct.cc
@@ -1048,6 +1054,7 @@ PRIVATE
     modules/audio_processing/utility/ooura_fft.cc
     modules/audio_processing/utility/ooura_fft.h
     modules/audio_processing/utility/ooura_fft_tables_common.h
+    modules/audio_processing/utility/ooura_fft_neon.cc
     modules/audio_processing/utility/ooura_fft_sse2.cc
     modules/audio_processing/utility/ooura_fft_tables_neon_sse2.h
     modules/audio_processing/vad/gmm.cc
@@ -1345,6 +1352,7 @@ PRIVATE
     modules/video_coding/codecs/vp9/vp9_impl.cc
     modules/video_processing/util/denoiser_filter.cc
     modules/video_processing/util/denoiser_filter_c.cc
+    modules/video_processing/util/denoiser_filter_neon.cc
     modules/video_processing/util/denoiser_filter_sse2.cc
     modules/video_processing/util/noise_estimation.cc
     modules/video_processing/util/skin_detection.cc
@@ -1378,8 +1386,10 @@ PRIVATE
     common_audio/audio_converter.cc
     common_audio/audio_util.cc
     common_audio/channel_buffer.cc
-    common_audio/fir_filter_c.cc
     common_audio/fir_filter_factory.cc
+    common_audio/fir_filter_c.cc
+    common_audio/fir_filter_neon.cc
+    common_audio/fir_filter_neon.h
     common_audio/fir_filter_sse.cc
     common_audio/fir_filter_sse.h
     common_audio/real_fourier.cc
@@ -1387,6 +1397,7 @@ PRIVATE
     common_audio/resampler/push_resampler.cc
     common_audio/resampler/push_sinc_resampler.cc
     common_audio/resampler/resampler.cc
+    common_audio/resampler/sinc_resampler_neon.cc
     common_audio/resampler/sinc_resampler_sse.cc
     common_audio/resampler/sinc_resampler.cc
     common_audio/resampler/sinusoidal_linear_chirp_source.cc
@@ -1404,8 +1415,10 @@ PRIVATE
     common_audio/signal_processing/filter_ar_fast_q12.c
     common_audio/signal_processing/copy_set_operations.c
     common_audio/signal_processing/cross_correlation.c
+    common_audio/signal_processing/cross_correlation_neon.c
     common_audio/signal_processing/division_operations.c
     common_audio/signal_processing/downsample_fast.c
+    common_audio/signal_processing/downsample_fast_neon.c
     common_audio/signal_processing/energy.c
     common_audio/signal_processing/filter_ar.c
     common_audio/signal_processing/filter_ma_fast_q12.c
@@ -1415,6 +1428,7 @@ PRIVATE
     common_audio/signal_processing/levinson_durbin.c
     common_audio/signal_processing/lpc_to_refl_coef.c
     common_audio/signal_processing/min_max_operations.c
+    common_audio/signal_processing/min_max_operations_neon.c
     common_audio/signal_processing/randomization_functions.c
     common_audio/signal_processing/real_fft.c
     common_audio/signal_processing/refl_coef_to_lpc.c
@@ -1703,6 +1717,40 @@ if (NOT WIN32)
         rtc_base/task_queue_win.cc
         rtc_base/task_queue_win.h
         api/task_queue/default_task_queue_factory_win.cc
+    )
+endif()
+
+if ((NOT is_x86) AND (NOT is_x64))
+    remove_target_sources(tg_owt ${webrtc_loc}
+        common_audio/fir_filter_sse.cc
+        common_audio/fir_filter_sse.h
+        common_audio/resampler/sinc_resampler_sse.cc
+        modules/audio_processing/utility/ooura_fft_sse2.cc
+        modules/video_processing/util/denoiser_filter_sse2.cc
+    )
+endif()
+
+if (arm_use_neon)
+    target_compile_definitions(tg_owt
+    PRIVATE
+        WEBRTC_HAS_NEON
+    )
+else()
+    remove_target_sources(tg_owt ${webrtc_loc}
+        common_audio/fir_filter_neon.cc
+        common_audio/fir_filter_neon.h
+        common_audio/resampler/sinc_resampler_neon.cc
+        common_audio/signal_processing/cross_correlation_neon.c
+        common_audio/signal_processing/downsample_fast_neon.c
+        common_audio/signal_processing/min_max_operations_neon.c
+        modules/audio_coding/codecs/isac/fix/source/entropy_coding_neon.c
+        modules/audio_coding/codecs/isac/fix/source/filterbanks_neon.c
+        modules/audio_coding/codecs/isac/fix/source/filters_neon.c
+        modules/audio_coding/codecs/isac/fix/source/lattice_neon.c
+        modules/audio_coding/codecs/isac/fix/source/transform_neon.c
+        modules/audio_processing/utility/ooura_fft_neon.cc
+        modules/video_processing/util/denoiser_filter_neon.cc
+        modules/audio_processing/aecm/aecm_core_neon.cc
     )
 endif()
 


### PR DESCRIPTION
This is the final in the series of commits (split into separate pull requests on @vitlav's suggestion on https://github.com/desktop-app/tg_owt/pull/18) that adds support for building tg_owt on ARM and aarch64.

Together with the other commits (https://github.com/desktop-app/tg_owt/pull/19 https://github.com/desktop-app/tg_owt/pull/20 https://github.com/desktop-app/tg_owt/pull/21 https://github.com/desktop-app/tg_owt/pull/22 https://github.com/desktop-app/tg_owt/pull/23), I was able to build the library on a Raspberry Pi B+ (armv6) running Debian Buster, on an ARMv7 Android tablet with Debian Buster in a chroot, a repurporsed Motorola Moto G running PostmarketOS (armv7), as well as a Pine64 PinePhone (aarch64) running PostmarketOS, and of course, a desktop PC with a 64-bit x86 processor (debian buster as well).

While I did manage to build the library, it is possible that there might be unresolved symbols, since it is a static library, and I didn't attempt to link it into anything (getting this project to build on aarch64 was suggested to me by the flatpak people as a neccessary step in getting Telegram on aarch64 to build).  If this is the case, it should be reasonably easy to detect which files are missing and how to add them to the compilation lists.