### PR TITLE
Use protobuf to generate missing sources and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_policy(SET CMP0091 NEW)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(TG_OWT_SPECIAL_TARGET "" CACHE STRING "Use special platform target, like 'macstore' for Mac App Store.")
+set(TG_OWT_USE_PROTOBUF "Use protobuf to generate additional headers. Useful for packaged build." OFF)
 
 if (NOT TG_OWT_SPECIAL_TARGET STREQUAL "osx")
     set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Minimum OS X deployment version" FORCE)
@@ -52,6 +53,12 @@ if (APPLE)
     include(cmake/libsdkmacos.cmake)
 endif()
 
+# Use a separate subdirectory, because it will be exported as an INTERFACE
+# for the generated sources and headers.
+if (TG_OWT_USE_PROTOBUF)
+    add_subdirectory(cmake/protobuf)
+endif()
+
 add_library(tg_owt STATIC)
 init_target(tg_owt)
 
@@ -88,6 +95,13 @@ else()
         tg_owt::libusrsctp
         tg_owt::libvpx
         tg_owt::libyuv
+    )
+endif()
+
+if (TG_OWT_USE_PROTOBUF)
+    target_link_libraries(tg_owt
+    PRIVATE
+        tg_owt::proto
     )
 endif()
 
@@ -1548,6 +1562,8 @@ PRIVATE
     logging/rtc_event_log/encoder/blob_encoding.cc
     logging/rtc_event_log/encoder/delta_encoding.cc
     logging/rtc_event_log/encoder/rtc_event_log_encoder_common.cc
+    logging/rtc_event_log/encoder/rtc_event_log_encoder_legacy.cc
+    logging/rtc_event_log/encoder/rtc_event_log_encoder_new_format.cc
     logging/rtc_event_log/encoder/var_int.cc
     logging/rtc_event_log/events/rtc_event_alr_state.cc
     logging/rtc_event_log/events/rtc_event_audio_network_adaptation.cc
@@ -1727,6 +1743,13 @@ PRIVATE
     stats/rtc_stats.cc
     stats/rtcstats_objects.cc
 )
+
+if (NOT TG_OWT_USE_PROTOBUF)
+    remove_target_sources(tg_owt ${webrtc_loc}
+        logging/rtc_event_log/encoder/rtc_event_log_encoder_legacy.cc
+        logging/rtc_event_log/encoder/rtc_event_log_encoder_new_format.cc
+    )
+endif()
 
 if (NOT WIN32)
     remove_target_sources(tg_owt ${webrtc_loc}

--- a/cmake/protobuf/CMakeLists.txt
+++ b/cmake/protobuf/CMakeLists.txt
@@ -1,0 +1,40 @@
+find_package(Protobuf REQUIRED)
+
+add_library(proto OBJECT)
+init_target(proto)
+add_library(tg_owt::proto ALIAS proto)
+
+target_compile_definitions(proto
+PRIVATE
+    HAVE_CONFIG_H
+)
+
+set(proto_files
+    ${webrtc_loc}/logging/rtc_event_log/rtc_event_log.proto
+    ${webrtc_loc}/logging/rtc_event_log/rtc_event_log2.proto
+)
+
+protobuf_generate_cpp(proto_sources proto_headers ${proto_files})
+set_source_files_properties(${proto_sources} ${proto_headers} PROPERTIES GENERATED TRUE)
+
+target_sources(proto
+PRIVATE
+    ${proto_headers}
+    ${proto_sources}
+)
+
+# CMAKE_CURRENT_BINARY_DIR is always used by protobuf_generate_cpp
+# to place the generated files. It cannot be changed or overridden.
+# We have to push it to the main project because the generated sources
+# and headers will be used as include files.
+target_include_directories(proto
+INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+PRIVATE
+    ${Protobuf_INCLUDE_DIRS}
+)
+
+target_link_libraries(proto
+PRIVATE
+    ${Protobuf_LIBRARIES}
+)

--- a/src/logging/rtc_event_log/encoder/rtc_event_log_encoder_legacy.cc
+++ b/src/logging/rtc_event_log/encoder/rtc_event_log_encoder_legacy.cc
@@ -60,7 +60,7 @@ RTC_PUSH_IGNORING_WUNDEF()
 #ifdef WEBRTC_ANDROID_PLATFORM_BUILD
 #include "external/webrtc/webrtc/logging/rtc_event_log/rtc_event_log.pb.h"
 #else
-#include "logging/rtc_event_log/rtc_event_log.pb.h"
+#include <rtc_event_log.pb.h>
 #endif
 RTC_POP_IGNORING_WUNDEF()
 

--- a/src/logging/rtc_event_log/encoder/rtc_event_log_encoder_new_format.cc
+++ b/src/logging/rtc_event_log/encoder/rtc_event_log_encoder_new_format.cc
@@ -66,7 +66,7 @@ RTC_PUSH_IGNORING_WUNDEF()
 #ifdef WEBRTC_ANDROID_PLATFORM_BUILD
 #include "external/webrtc/webrtc/logging/rtc_event_log/rtc_event_log2.pb.h"
 #else
-#include "logging/rtc_event_log/rtc_event_log2.pb.h"
+#include <rtc_event_log2.pb.h>
 #endif
 RTC_POP_IGNORING_WUNDEF()
 


### PR DESCRIPTION
Use protobuf to generate missing sources and headers.

This will fix the following:

```
/usr/bin/ld: /usr/lib64/libtg_owt.so.0.0.0: undefined reference to `vtable for webrtc::RtcEventLogEncoderLegacy'
/usr/bin/ld: /usr/lib64/libtg_owt.so.0.0.0: undefined reference to `vtable for webrtc::RtcEventLogEncoderNewFormat'
collect2: error: ld returned 1 exit status
```