### PR TITLE
Add a bare-bones README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# tg_owt
+
+## Building
+
+Depenendies necessary for building on Linux:
+
+ - ALSA library development files
+ - CMake
+ - FFmpeg development files
+ - JPEG development files
+ - OpenSSL development files
+ - Opus development files
+ - Protobuf development files
+ - PulseAudio development files
+ - yasm
+ 
+ Depending on your kernel configuration you may also need to install BSD compatibility headers


### PR DESCRIPTION
Only contains information about dependencies necessary for building on Linux. I wouldn't say that this does what's necessary for https://github.com/desktop-app/tg_owt/issues/28 to be closed as it doesn't really explain what the library is for.