### PR TITLE
Added missing sources to the build

### DIFF
--- a/cmake/libabsl.cmake
+++ b/cmake/libabsl.cmake
@@ -12,7 +12,7 @@ PRIVATE
     # absl/base/internal/exponential_biased.cc
     # absl/base/internal/low_level_alloc.cc
     # absl/base/internal/periodic_sampler.cc
-    # absl/base/internal/raw_logging.cc
+    absl/base/internal/raw_logging.cc
     # absl/base/internal/scoped_set_env.cc
     # absl/base/internal/spinlock.cc
     # absl/base/internal/spinlock_wait.cc


### PR DESCRIPTION
Should fix linkage issue for shared builds:

```
/usr/bin/ld: /usr/lib64/libtg_owt.so.0.0.0: undefined reference to `absl::raw_logging_internal::RawLog(absl::LogSeverity, char const*, int, char const*, ...)'
/usr/bin/ld: /usr/lib64/libtg_owt.so.0.0.0: undefined reference to `absl::raw_logging_internal::internal_log_function[abi:cxx11]'
```