### PR TITLE
Fix build with LibreSSL

### DIFF
--- a/src/rtc_base/openssl_stream_adapter.cc
+++ b/src/rtc_base/openssl_stream_adapter.cc
@@ -17,8 +17,11 @@
 #include <openssl/tls1.h>
 #include <openssl/x509v3.h>
 #ifndef OPENSSL_IS_BORINGSSL
-#include <openssl/dtls1.h>
 #include <openssl/ssl.h>
+#ifdef LIBRESSL_VERSION_NUMBER
+#include <openssl/ssl3.h>
+#endif
+#include <openssl/dtls1.h>
 #endif
 
 #include <memory>
@@ -392,8 +395,10 @@ SSLProtocolVersion OpenSSLStreamAdapter::GetSslVersion() const {
   if (ssl_mode_ == SSL_MODE_DTLS) {
     if (ssl_version == DTLS1_VERSION) {
       return SSL_PROTOCOL_DTLS_10;
+#ifndef LIBRESSL_VERSION_NUMBER
     } else if (ssl_version == DTLS1_2_VERSION) {
       return SSL_PROTOCOL_DTLS_12;
+#endif
     }
   } else {
     if (ssl_version == TLS1_VERSION) {
@@ -985,15 +990,27 @@ SSL_CTX* OpenSSLStreamAdapter::SetupSSLContext() {
       case SSL_PROTOCOL_TLS_12:
       default:
         SSL_CTX_set_max_proto_version(
+#ifdef LIBRESSL_VERSION_NUMBER
+            ctx, TLS1_2_VERSION);
+#else
             ctx, ssl_mode_ == SSL_MODE_DTLS ? DTLS1_2_VERSION : TLS1_2_VERSION);
+#endif
         break;
     }
   } else {
     // TODO(https://bugs.webrtc.org/10261): Make this the default in M84.
     SSL_CTX_set_min_proto_version(
+#ifdef LIBRESSL_VERSION_NUMBER
+        ctx, TLS1_2_VERSION);
+#else
         ctx, ssl_mode_ == SSL_MODE_DTLS ? DTLS1_2_VERSION : TLS1_2_VERSION);
+#endif
     SSL_CTX_set_max_proto_version(
+#ifdef LIBRESSL_VERSION_NUMBER
+        ctx, TLS1_2_VERSION);
+#else
         ctx, ssl_mode_ == SSL_MODE_DTLS ? DTLS1_2_VERSION : TLS1_2_VERSION);
+#endif
   }
 
 #ifdef OPENSSL_IS_BORINGSSL


### PR DESCRIPTION
With LibreSSL, the build would fail:
```
FAILED: CMakeFiles/tg_owt.dir/src/rtc_base/openssl_stream_adapter.cc.o 
/usr/bin/c++ -DHAVE_NETINET_IN_H -DHAVE_WEBRTC_VIDEO -DRTC_ENABLE_VP9 -DWEBRTC_APM_DEBUG_DUMP=0 -DWEBRTC_ENABLE_LINUX_ALSA -DWEBRTC_ENABLE_LINUX_PULSE -DWEBRTC_ENABLE_PROTOBUF=0 -DWEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE -DWEBRTC_LIBRARY_IMPL -DWEBRTC_LINUX -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=1 -DWEBRTC_OPUS_VARIABLE_COMPLEXITY=0 -DWEBRTC_POSIX -DWEBRTC_USE_BUILTIN_ISAC_FLOAT -DWEBRTC_USE_H264 -I/usr/local/include -I/usr/local/include/opus -I../../src -I../../src/third_party/abseil-cpp -I../../src/third_party/libyuv/include -I../../src/third_party/pffft/src -I../../src/third_party/libsrtp/include -I../../src/third_party/libsrtp/crypto/include -I../../src/third_party/libvpx/source/libvpx -I../../src/third_party/libvpx/source/config -I../../src/third_party/libvpx/source/config/linux/x64 -O2 -pipe -fstack-protector-strong -fno-strict-aliasing  -DNDEBUG -O2 -pipe -fstack-protector-strong -fno-strict-aliasing  -DNDEBUG -Wno-deprecated-declarations -Wno-attributes -Wno-narrowing -Wno-return-type -std=gnu++17 -MD -MT CMakeFiles/tg_owt.dir/src/rtc_base/openssl_stream_adapter.cc.o -MF CMakeFiles/tg_owt.dir/src/rtc_base/openssl_stream_adapter.cc.o.d -o CMakeFiles/tg_owt.dir/src/rtc_base/openssl_stream_adapter.cc.o -c ../../src/rtc_base/openssl_stream_adapter.cc
In file included from ../../src/rtc_base/openssl_stream_adapter.cc:20:
/usr/local/include/openssl/dtls1.h:110:2: error: unknown type name 'SSL_SESSION'
        SSL_SESSION *session;
        ^
/usr/local/include/openssl/dtls1.h:173:2: error: unknown type name 'SSL3_BUFFER'
        SSL3_BUFFER    rbuf;
        ^
/usr/local/include/openssl/dtls1.h:174:2: error: unknown type name 'SSL3_RECORD'
        SSL3_RECORD    rrec;
        ^
../../src/rtc_base/openssl_stream_adapter.cc:395:31: error: use of undeclared identifier 'DTLS1_2_VERSION'
    } else if (ssl_version == DTLS1_2_VERSION) {
                              ^
../../src/rtc_base/openssl_stream_adapter.cc:988:47: error: use of undeclared identifier 'DTLS1_2_VERSION'
            ctx, ssl_mode_ == SSL_MODE_DTLS ? DTLS1_2_VERSION : TLS1_2_VERSION);
                                              ^
../../src/rtc_base/openssl_stream_adapter.cc:994:43: error: use of undeclared identifier 'DTLS1_2_VERSION'
        ctx, ssl_mode_ == SSL_MODE_DTLS ? DTLS1_2_VERSION : TLS1_2_VERSION);
                                          ^
../../src/rtc_base/openssl_stream_adapter.cc:996:43: error: use of undeclared identifier 'DTLS1_2_VERSION'
        ctx, ssl_mode_ == SSL_MODE_DTLS ? DTLS1_2_VERSION : TLS1_2_VERSION);
                                          ^
7 errors generated.
```

Commit message explains more.