### PR TITLE
Avoid SSE2 usage on i386 without properly checks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1769,7 +1769,12 @@ if (NOT WIN32)
     )
 endif()
 
-if ((NOT is_x86) AND (NOT is_x64))
+if (x86_has_sse2)
+    target_compile_definitions(tg_owt
+    PRIVATE
+        WEBRTC_HAS_SSE2
+    )
+else()
     remove_target_sources(tg_owt ${webrtc_loc}
         common_audio/fir_filter_sse.cc
         common_audio/fir_filter_sse.h

--- a/cmake/init_target.cmake
+++ b/cmake/init_target.cmake
@@ -75,13 +75,6 @@ function(init_target target_name) # init_target(my_target folder_name)
             endif()
         endif()
 
-        if (is_x86)
-            target_compile_options(${target_name}
-            PRIVATE
-                -msse2
-            )
-        endif()
-
         target_compile_definitions(${target_name}
         PRIVATE
             HAVE_NETINET_IN_H

--- a/cmake/libpffft.cmake
+++ b/cmake/libpffft.cmake
@@ -15,7 +15,7 @@ PRIVATE
     _USE_MATH_DEFINES
 )
 
-if (NOT is_x86 AND NOT is_x64 AND NOT arm_use_neon)
+if (NOT x86_has_sse2 AND NOT arm_use_neon)
     target_compile_definitions(libpffft
     PRIVATE
         PFFFT_SIMD_DISABLE

--- a/src/modules/audio_processing/aec3/adaptive_fir_filter.cc
+++ b/src/modules/audio_processing/aec3/adaptive_fir_filter.cc
@@ -88,7 +88,7 @@ void ComputeFrequencyResponse_Neon(
 
 #if defined(WEBRTC_ARCH_X86_FAMILY)
 // Computes and stores the frequency response of the filter.
-void ComputeFrequencyResponse_Sse2(
+RTC_TARGET_SSE2 void ComputeFrequencyResponse_Sse2(
     size_t num_partitions,
     const std::vector<std::vector<FftData>>& H,
     std::vector<std::array<float, kFftLengthBy2Plus1>>* H2) {
@@ -210,10 +210,11 @@ void AdaptPartitions_Neon(const RenderBuffer& render_buffer,
 
 #if defined(WEBRTC_ARCH_X86_FAMILY)
 // Adapts the filter partitions. (SSE2 variant)
-void AdaptPartitions_Sse2(const RenderBuffer& render_buffer,
-                          const FftData& G,
-                          size_t num_partitions,
-                          std::vector<std::vector<FftData>>* H) {
+RTC_TARGET_SSE2 void AdaptPartitions_Sse2(
+    const RenderBuffer& render_buffer,
+    const FftData& G,
+    size_t num_partitions,
+    std::vector<std::vector<FftData>>* H) {
   rtc::ArrayView<const std::vector<FftData>> render_buffer_data =
       render_buffer.GetFftBuffer();
   const size_t num_render_channels = render_buffer_data[0].size();
@@ -375,10 +376,11 @@ void ApplyFilter_Neon(const RenderBuffer& render_buffer,
 
 #if defined(WEBRTC_ARCH_X86_FAMILY)
 // Produces the filter output (SSE2 variant).
-void ApplyFilter_Sse2(const RenderBuffer& render_buffer,
-                      size_t num_partitions,
-                      const std::vector<std::vector<FftData>>& H,
-                      FftData* S) {
+RTC_TARGET_SSE2 void ApplyFilter_Sse2(
+    const RenderBuffer& render_buffer,
+    size_t num_partitions,
+    const std::vector<std::vector<FftData>>& H,
+    FftData* S) {
   // const RenderBuffer& render_buffer,
   //                     rtc::ArrayView<const FftData> H,
   //                     FftData* S) {

--- a/src/modules/audio_processing/aec3/adaptive_fir_filter_erl.cc
+++ b/src/modules/audio_processing/aec3/adaptive_fir_filter_erl.cc
@@ -57,7 +57,7 @@ void ErlComputer_NEON(
 #if defined(WEBRTC_ARCH_X86_FAMILY)
 // Computes and stores the echo return loss estimate of the filter, which is the
 // sum of the partition frequency responses.
-void ErlComputer_SSE2(
+RTC_TARGET_SSE2 void ErlComputer_SSE2(
     const std::vector<std::array<float, kFftLengthBy2Plus1>>& H2,
     rtc::ArrayView<float> erl) {
   std::fill(erl.begin(), erl.end(), 0.f);

--- a/src/modules/audio_processing/aec3/fft_data.h
+++ b/src/modules/audio_processing/aec3/fft_data.h
@@ -45,7 +45,7 @@ struct FftData {
                 rtc::ArrayView<float> power_spectrum) const {
     RTC_DCHECK_EQ(kFftLengthBy2Plus1, power_spectrum.size());
     switch (optimization) {
-#if defined(WEBRTC_ARCH_X86_FAMILY)
+#if defined(WEBRTC_ARCH_X86_FAMILY) && defined(WEBRTC_HAS_SSE2)
       case Aec3Optimization::kSse2: {
         constexpr int kNumFourBinBands = kFftLengthBy2 / 4;
         constexpr int kLimit = kNumFourBinBands * 4;

--- a/src/modules/audio_processing/aec3/matched_filter.cc
+++ b/src/modules/audio_processing/aec3/matched_filter.cc
@@ -144,14 +144,14 @@ void MatchedFilterCore_NEON(size_t x_start_index,
 
 #if defined(WEBRTC_ARCH_X86_FAMILY)
 
-void MatchedFilterCore_SSE2(size_t x_start_index,
-                            float x2_sum_threshold,
-                            float smoothing,
-                            rtc::ArrayView<const float> x,
-                            rtc::ArrayView<const float> y,
-                            rtc::ArrayView<float> h,
-                            bool* filters_updated,
-                            float* error_sum) {
+RTC_TARGET_SSE2 void MatchedFilterCore_SSE2(size_t x_start_index,
+                                            float x2_sum_threshold,
+                                            float smoothing,
+                                            rtc::ArrayView<const float> x,
+                                            rtc::ArrayView<const float> y,
+                                            rtc::ArrayView<float> h,
+                                            bool* filters_updated,
+                                            float* error_sum) {
   const int h_size = static_cast<int>(h.size());
   const int x_size = static_cast<int>(x.size());
   RTC_DCHECK_EQ(0, h_size % 4);

--- a/src/modules/audio_processing/aec3/vector_math.h
+++ b/src/modules/audio_processing/aec3/vector_math.h
@@ -42,7 +42,7 @@ class VectorMath {
   // Elementwise square root.
   void Sqrt(rtc::ArrayView<float> x) {
     switch (optimization_) {
-#if defined(WEBRTC_ARCH_X86_FAMILY)
+#if defined(WEBRTC_ARCH_X86_FAMILY) && defined(WEBRTC_HAS_SSE2)
       case Aec3Optimization::kSse2: {
         const int x_size = static_cast<int>(x.size());
         const int vector_limit = x_size >> 2;
@@ -116,7 +116,7 @@ class VectorMath {
     RTC_DCHECK_EQ(z.size(), x.size());
     RTC_DCHECK_EQ(z.size(), y.size());
     switch (optimization_) {
-#if defined(WEBRTC_ARCH_X86_FAMILY)
+#if defined(WEBRTC_ARCH_X86_FAMILY) && defined(WEBRTC_HAS_SSE2)
       case Aec3Optimization::kSse2: {
         const int x_size = static_cast<int>(x.size());
         const int vector_limit = x_size >> 2;
@@ -162,7 +162,7 @@ class VectorMath {
   void Accumulate(rtc::ArrayView<const float> x, rtc::ArrayView<float> z) {
     RTC_DCHECK_EQ(z.size(), x.size());
     switch (optimization_) {
-#if defined(WEBRTC_ARCH_X86_FAMILY)
+#if defined(WEBRTC_ARCH_X86_FAMILY) && defined(WEBRTC_HAS_SSE2)
       case Aec3Optimization::kSse2: {
         const int x_size = static_cast<int>(x.size());
         const int vector_limit = x_size >> 2;

--- a/src/modules/audio_processing/agc2/rnn_vad/rnn.cc
+++ b/src/modules/audio_processing/agc2/rnn_vad/rnn.cc
@@ -229,7 +229,7 @@ void ComputeFullyConnectedLayerOutput(
 
 #if defined(WEBRTC_ARCH_X86_FAMILY)
 // Fully connected layer SSE2 implementation.
-void ComputeFullyConnectedLayerOutputSse2(
+RTC_TARGET_SSE2 void ComputeFullyConnectedLayerOutputSse2(
     size_t input_size,
     size_t output_size,
     rtc::ArrayView<const float> input,

--- a/src/rtc_base/system/inline.h
+++ b/src/rtc_base/system/inline.h
@@ -28,4 +28,10 @@
 
 #endif
 
+#if defined(__GNUC__) && !defined(__SSE2__)
+#define RTC_TARGET_SSE2 __attribute__((__target__("sse2")))
+#else
+#define RTC_TARGET_SSE2
+#endif
+
 #endif  // RTC_BASE_SYSTEM_INLINE_H_


### PR DESCRIPTION
The patch introduces a new switch for CMake, -DTG_OWT_ARCH_X86_FORCE_SSE=OFF. It may be used for activate runtime checking via the "cpuid" assembler instruction whether CPU supports the extension. But default, we still assume that SSE2 is always available on a host machine.