### PR TITLE
Export proto target when TG_OWT_USE_PROTOBUF is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2166,6 +2166,9 @@ set(export_targets
     libyuv
     ${platform_export}
 )
+if (TG_OWT_USE_PROTOBUF)
+    list(APPEND export_targets proto)
+endif()
 
 export(
     TARGETS ${export_targets}


### PR DESCRIPTION
Fixes the following:

```
$ cmake -DBUILD_SHARED_LIBS=OFF -DTG_OWT_USE_PROTOBUF=ON
-- Processor architecture is 64-bit x86.
-- Configuring done
CMake Error: install(EXPORT "tg_owtTargets" ...) includes target "tg_owt" which requires target "proto" that is not in any export set.
CMake Error in CMakeLists.txt:
  export called with target "tg_owt" which requires target "proto" that is
  not in any export set.


-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```