### PR TITLE
Don't use dlsym with XRandr

### DIFF
--- a/src/modules/desktop_capture/linux/screen_capturer_x11.h
+++ b/src/modules/desktop_capture/linux/screen_capturer_x11.h
@@ -106,10 +106,6 @@ class ScreenCapturerX11 : public DesktopCapturer,
   // selected_monitor_rect_ should be updated as well.
   // Setting it to kFullDesktopScreenId here might be misleading.
   Atom selected_monitor_name_ = 0;
-  typedef XRRMonitorInfo* (*get_monitors_func)(Display*, Window, Bool, int*);
-  typedef void (*free_monitors_func)(XRRMonitorInfo*);
-  get_monitors_func get_monitors_ = nullptr;
-  free_monitors_func free_monitors_ = nullptr;
 
   // XFixes.
   bool has_xfixes_ = false;


### PR DESCRIPTION
Since tdesktop links to XRandr statically, this has no sense

Fixes https://github.com/telegramdesktop/tdesktop/issues/16482