### PR TITLE
Set of patches to compile and properly work on FreeBSD

### DIFF
--- a/cmake/libwebrtcbuild.cmake
+++ b/cmake/libwebrtcbuild.cmake
@@ -52,19 +52,35 @@ if (WIN32)
     INTERFACE
         WEBRTC_WIN
     )
-elseif (APPLE)
-    target_compile_definitions(libwebrtcbuild
-    INTERFACE
-        WEBRTC_POSIX
-        WEBRTC_MAC
-    )
 else()
     target_compile_definitions(libwebrtcbuild
     INTERFACE
         WEBRTC_POSIX
-        WEBRTC_LINUX
-        WEBRTC_USE_X11
     )
+
+    if (APPLE)
+        target_compile_definitions(libwebrtcbuild
+        INTERFACE
+            WEBRTC_MAC
+        )
+    else()
+        target_compile_definitions(libwebrtcbuild
+        INTERFACE
+            WEBRTC_USE_X11
+        )
+    endif()
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_compile_definitions(libwebrtcbuild
+        INTERFACE
+            WEBRTC_LINUX
+        )
+    elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+        target_compile_definitions(libwebrtcbuild
+        INTERFACE
+            WEBRTC_FREEBSD
+        )
+    endif()
 endif()
 
 target_include_directories(libwebrtcbuild

--- a/src/rtc_base/byte_order.h
+++ b/src/rtc_base/byte_order.h
@@ -88,8 +88,10 @@
 #error WEBRTC_ARCH_BIG_ENDIAN or WEBRTC_ARCH_LITTLE_ENDIAN must be defined.
 #endif  // defined(WEBRTC_ARCH_LITTLE_ENDIAN)
 
-#elif defined(WEBRTC_POSIX)
+#elif defined(WEBRTC_LINUX)
 #include <endian.h>
+#elif defined(WEBRTC_FREEBSD)
+#include <sys/endian.h>
 #else
 #error "Missing byte order functions for this arch."
 #endif  // defined(WEBRTC_MAC)

--- a/src/rtc_base/ip_address.cc
+++ b/src/rtc_base/ip_address.cc
@@ -14,9 +14,6 @@
 #ifdef OPENBSD
 #include <netinet/in_systm.h>
 #endif
-#ifndef __native_client__
-#include <netinet/ip.h>
-#endif
 #include <netdb.h>
 #endif
 

--- a/src/rtc_base/physical_socket_server.cc
+++ b/src/rtc_base/physical_socket_server.cc
@@ -70,7 +70,7 @@ typedef void* SockOptArg;
 
 #endif  // WEBRTC_POSIX
 
-#if defined(WEBRTC_POSIX) && !defined(WEBRTC_MAC) && !defined(__native_client__)
+#if defined(WEBRTC_LINUX)
 
 int64_t GetSocketRecvTimestamp(int socket) {
   struct timeval tv_ioctl;
@@ -344,7 +344,7 @@ int PhysicalSocket::SetOption(Option opt, int value) {
 int PhysicalSocket::Send(const void* pv, size_t cb) {
   int sent = DoSend(
       s_, reinterpret_cast<const char*>(pv), static_cast<int>(cb),
-#if defined(WEBRTC_LINUX) && !defined(WEBRTC_ANDROID)
+#if defined(WEBRTC_POSIX) && !defined(WEBRTC_ANDROID) && !defined(WEBRTC_MAC)
       // Suppress SIGPIPE. Without this, attempting to send on a socket whose
       // other end is closed will result in a SIGPIPE signal being raised to
       // our process, which by default will terminate the process, which we
@@ -373,7 +373,7 @@ int PhysicalSocket::SendTo(const void* buffer,
   size_t len = addr.ToSockAddrStorage(&saddr);
   int sent =
       DoSendTo(s_, static_cast<const char*>(buffer), static_cast<int>(length),
-#if defined(WEBRTC_LINUX) && !defined(WEBRTC_ANDROID)
+#if defined(WEBRTC_POSIX) && !defined(WEBRTC_ANDROID) && !defined(WEBRTC_MAC)
                // Suppress SIGPIPE. See above for explanation.
                MSG_NOSIGNAL,
 #else
@@ -564,13 +564,13 @@ int PhysicalSocket::TranslateOption(Option opt, int* slevel, int* sopt) {
       *slevel = IPPROTO_IP;
       *sopt = IP_DONTFRAGMENT;
       break;
-#elif defined(WEBRTC_MAC) || defined(BSD) || defined(__native_client__)
-      RTC_LOG(LS_WARNING) << "Socket::OPT_DONTFRAGMENT not supported.";
-      return -1;
-#elif defined(WEBRTC_POSIX)
+#elif defined(WEBRTC_LINUX)
       *slevel = IPPROTO_IP;
       *sopt = IP_MTU_DISCOVER;
       break;
+#else
+      RTC_LOG(LS_WARNING) << "Socket::OPT_DONTFRAGMENT not supported.";
+      return -1;
 #endif
     case OPT_RCVBUF:
       *slevel = SOL_SOCKET;

--- a/src/rtc_base/platform_thread_types.cc
+++ b/src/rtc_base/platform_thread_types.cc
@@ -25,6 +25,11 @@ typedef HRESULT(WINAPI* RTC_SetThreadDescription)(HANDLE hThread,
                                                   PCWSTR lpThreadDescription);
 #endif
 
+#if defined(WEBRTC_FREEBSD)
+#include <sys/thr.h>
+#include <pthread_np.h>
+#endif
+
 namespace rtc {
 
 PlatformThreadId CurrentThreadId() {
@@ -39,6 +44,10 @@ PlatformThreadId CurrentThreadId() {
   return zx_thread_self();
 #elif defined(WEBRTC_LINUX)
   return syscall(__NR_gettid);
+#elif defined(WEBRTC_FREEBSD)
+  long tid;
+  thr_self(&tid);
+  return tid;
 #elif defined(__EMSCRIPTEN__)
   return static_cast<PlatformThreadId>(pthread_self());
 #else
@@ -107,6 +116,8 @@ void SetCurrentThreadName(const char* name) {
 #pragma warning(pop)
 #elif defined(WEBRTC_LINUX) || defined(WEBRTC_ANDROID)
   prctl(PR_SET_NAME, reinterpret_cast<unsigned long>(name));  // NOLINT
+#elif defined(WEBRTC_FREEBSD)
+  pthread_setname_np(pthread_self(), name);
 #elif defined(WEBRTC_MAC) || defined(WEBRTC_IOS)
   pthread_setname_np(name);
 #endif

--- a/src/system_wrappers/source/cpu_info.cc
+++ b/src/system_wrappers/source/cpu_info.cc
@@ -12,7 +12,7 @@
 
 #if defined(WEBRTC_WIN)
 #include <windows.h>
-#elif defined(WEBRTC_LINUX)
+#elif defined(WEBRTC_LINUX) || defined(WEBRTC_FREEBSD)
 #include <unistd.h>
 #elif defined(WEBRTC_MAC)
 #include <sys/sysctl.h>
@@ -30,7 +30,7 @@ static int DetectNumberOfCores() {
   SYSTEM_INFO si;
   GetNativeSystemInfo(&si);
   number_of_cores = static_cast<int>(si.dwNumberOfProcessors);
-#elif defined(WEBRTC_LINUX) || defined(WEBRTC_ANDROID)
+#elif defined(WEBRTC_LINUX) || defined(WEBRTC_ANDROID) || defined(WEBRTC_FREEBSD)
   number_of_cores = static_cast<int>(sysconf(_SC_NPROCESSORS_ONLN));
   if (number_of_cores < 0) {
     RTC_LOG(LS_ERROR) << "Failed to get number of cores";


### PR DESCRIPTION
- Provide cmake variable and preprocessor define for FreeBSD.
- Treat FreeBSD different to Linux where they differ.
- Mark POSIX interfaces as POSIX and Linux as Linux with corresponding preprocessor define.