### PR TITLE
Build on OpenBSD

### DIFF
--- a/cmake/libusrsctp.cmake
+++ b/cmake/libusrsctp.cmake
@@ -25,6 +25,11 @@ elseif (APPLE)
         HAVE_SA_LEN
         HAVE_SCONN_LEN
     )
+elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    target_compile_definitions(libusrsctp
+    PRIVATE
+        __Userspace_os_OpenBSD
+    )
 else()
     target_compile_definitions(libusrsctp
     PRIVATE

--- a/cmake/libwebrtcbuild.cmake
+++ b/cmake/libwebrtcbuild.cmake
@@ -81,6 +81,11 @@ else()
         INTERFACE
             WEBRTC_FREEBSD
         )
+    elseif (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+        target_compile_definitions(libwebrtcbuild
+        INTERFACE
+            WEBRTC_OPENBSD
+        )
     endif()
 endif()
 

--- a/src/rtc_base/byte_order.h
+++ b/src/rtc_base/byte_order.h
@@ -90,7 +90,7 @@
 
 #elif defined(WEBRTC_LINUX)
 #include <endian.h>
-#elif defined(WEBRTC_FREEBSD)
+#elif defined(WEBRTC_FREEBSD) || defined(WEBRTC_OPENBSD)
 #include <sys/endian.h>
 #else
 #error "Missing byte order functions for this arch."

--- a/src/rtc_base/platform_thread_types.cc
+++ b/src/rtc_base/platform_thread_types.cc
@@ -27,6 +27,8 @@ typedef HRESULT(WINAPI* RTC_SetThreadDescription)(HANDLE hThread,
 
 #if defined(WEBRTC_FREEBSD)
 #include <pthread_np.h>
+#elif defined(WEBRTC_OPENBSD)
+#include <pthread_np.h>
 #endif
 
 namespace rtc {
@@ -115,6 +117,8 @@ void SetCurrentThreadName(const char* name) {
   prctl(PR_SET_NAME, reinterpret_cast<unsigned long>(name));  // NOLINT
 #elif defined(WEBRTC_FREEBSD)
   pthread_setname_np(pthread_self(), name);
+#elif defined(WEBRTC_OPENBSD)
+  pthread_set_name_np(pthread_self(), name);
 #elif defined(WEBRTC_MAC) || defined(WEBRTC_IOS)
   pthread_setname_np(name);
 #endif

--- a/src/rtc_base/platform_thread_types.cc
+++ b/src/rtc_base/platform_thread_types.cc
@@ -25,9 +25,7 @@ typedef HRESULT(WINAPI* RTC_SetThreadDescription)(HANDLE hThread,
                                                   PCWSTR lpThreadDescription);
 #endif
 
-#if defined(WEBRTC_FREEBSD)
-#include <pthread_np.h>
-#elif defined(WEBRTC_OPENBSD)
+#if defined(WEBRTC_FREEBSD) || defined(WEBRTC_OPENBSD)
 #include <pthread_np.h>
 #endif
 

--- a/src/rtc_base/platform_thread_types.h
+++ b/src/rtc_base/platform_thread_types.h
@@ -39,7 +39,13 @@ typedef DWORD PlatformThreadRef;
 typedef zx_handle_t PlatformThreadId;
 typedef zx_handle_t PlatformThreadRef;
 #elif defined(WEBRTC_POSIX)
+#if defined(WEBRTC_MAC) || defined(WEBRTC_IOS)
+typedef mach_port_t PlatformThreadId;
+#elif defined(WEBRTC_LINUX)
 typedef pid_t PlatformThreadId;
+#else
+typedef intptr_t PlatformThreadId;
+#endif
 typedef pthread_t PlatformThreadRef;
 #endif
 


### PR DESCRIPTION
These are required to build on OpenBSD/amd64 7.0 -CURRENT.

Both `net/tg_owt` and `net/tdesktop` have been ported to OpenBSD and widely tested already.
`tg_owt` is built as shared library and I'd like to avoid carrying local patches as best as possible.