### PR TITLE
Use pthread_getthreadid_np() on FreeBSD.

### DIFF
--- a/src/modules/desktop_capture/linux/egl_dmabuf.cc
+++ b/src/modules/desktop_capture/linux/egl_dmabuf.cc
@@ -10,7 +10,6 @@
 
 #include "modules/desktop_capture/linux/egl_dmabuf.h"
 
-#include <asm/ioctl.h>
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <libdrm/drm_fourcc.h>

--- a/src/rtc_base/platform_thread_types.cc
+++ b/src/rtc_base/platform_thread_types.cc
@@ -26,7 +26,6 @@ typedef HRESULT(WINAPI* RTC_SetThreadDescription)(HANDLE hThread,
 #endif
 
 #if defined(WEBRTC_FREEBSD)
-#include <sys/thr.h>
 #include <pthread_np.h>
 #endif
 
@@ -45,9 +44,7 @@ PlatformThreadId CurrentThreadId() {
 #elif defined(WEBRTC_LINUX)
   return syscall(__NR_gettid);
 #elif defined(WEBRTC_FREEBSD)
-  long tid;
-  thr_self(&tid);
-  return tid;
+  return pthread_getthreadid_np();
 #elif defined(__EMSCRIPTEN__)
   return static_cast<PlatformThreadId>(pthread_self());
 #else


### PR DESCRIPTION
It is also unportable, but less legacy than thr_self().  It also
provides 32-bit return value, which matches PlatformThreadId on
all POSIX platforms of tg_owt.

Fixes:	27518db9
Fixes:	fa608fc9