### PR TITLE
video_capture: Use correct V4L2 header on OpenBSD

### DIFF
--- a/src/modules/video_capture/linux/device_info_linux.cc
+++ b/src/modules/video_capture/linux/device_info_linux.cc
@@ -18,7 +18,11 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 // v4l includes
+#if defined(__OpenBSD__)
+#include <sys/videoio.h>
+#else
 #include <linux/videodev2.h>
+#endif
 
 #include <vector>
 

--- a/src/modules/video_capture/linux/video_capture_linux.cc
+++ b/src/modules/video_capture/linux/video_capture_linux.cc
@@ -12,7 +12,11 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#if defined(__OpenBSD__)
+#include <sys/videoio.h>
+#else
 #include <linux/videodev2.h>
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
video(4) provides everything needed, the Linux header does not exist.
Tested on OpenBSD/amd64 7.0 -CURRENT.
