### PR TITLE
Fix TG_OWT_USE_PIPEWIRE=OFF build (on unix systems without Pipewire)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2217,6 +2217,13 @@ if (NOT TG_OWT_USE_PROTOBUF)
     )
 endif()
 
+if (NOT TG_OWT_USE_PIPEWIRE)
+    remove_target_sources(tg_owt ${webrtc_loc}
+        modules/desktop_capture/linux/base_capturer_pipewire.cc
+        modules/desktop_capture/linux/base_capturer_pipewire.h
+    )
+endif()
+
 if (NOT TG_OWT_BUILD_AUDIO_BACKENDS)
     remove_target_sources(tg_owt ${webrtc_loc}
         rtc_base/win/windows_version.cc


### PR DESCRIPTION
The desktop capture module is built unconditionally (on non-apple unix),
but systems like OpenBSD do not have a Pipewire port, thus the build
fails with
```
/usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/modules/desktop_capture/linux/base_capturer_pipewire.h:15:10: fatal error: 'pipewire/pipewire.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Build the file if and only if Pipewire support was enabled to fix this.
