### PR TITLE
libabsl: Use system include directories

### DIFF
--- a/cmake/external.cmake
+++ b/cmake/external.cmake
@@ -120,6 +120,9 @@ function(link_libabsl target_name)
                 absl::type_traits
                 absl::variant
             )
+            find_package(PkgConfig REQUIRED)
+            pkg_check_modules(ABSL REQUIRED QUIET absl_flags)
+            target_include_directories(${target_name} PRIVATE ${ABSL_INCLUDE_DIRS})
         endif()
     endif()
     if (NOT absl_FOUND)


### PR DESCRIPTION
Otherwise the build fails on at least OpenBSD.  This is because packages
live in the /usr/local/ namespace and no other dependency made the
`tg_owt` target include /usr/local/include/:

```
FAILED: CMakeFiles/tg_owt_avx2.dir/src/modules/audio_processing/aec3/vector_math_avx2.cc.o
/usr/ports/pobj/tg_owt-0.0.0.20220123/bin/c++ -DABSL_ALLOCATOR_NOTHROW=1 -DBWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0 -DHAVE_NETINET_IN_H -DHAVE_SCTP -DHAVE_WEBRTC_VIDEO -DNO_MAIN_THREAD_WRAPPING -DRTC_DISABLE_TRACE_EVENTS -DRTC_E
NABLE_VP9 -DWEBRTC_APM_DEBUG_DUMP=0 -DWEBRTC_DUMMY_AUDIO_BUILD -DWEBRTC_ENABLE_PROTOBUF=0 -DWEBRTC_HAVE_USRSCTP -DWEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE -DWEBRTC_LIBRARY_IMPL -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=1 -DWEBRTC_O
PENBSD -DWEBRTC_OPUS_SUPPORT_120MS_PTIME=1 -DWEBRTC_OPUS_VARIABLE_COMPLEXITY=0 -DWEBRTC_POSIX -DWEBRTC_USE_BUILTIN_ISAC_FLOAT -DWEBRTC_USE_H264 -DWEBRTC_USE_X11 -I/usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013
e291b44f9d1427fde3a90e/src -I/usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/third_party/libyuv/include -O2 -pipe -DNDEBUG -fPIC -Wno-deprecated-declarations -Wno-attributes -Wno-narro
wing -Wno-return-type -mavx2 -mfma -std=gnu++20 -MD -MT CMakeFiles/tg_owt_avx2.dir/src/modules/audio_processing/aec3/vector_math_avx2.cc.o -MF CMakeFiles/tg_owt_avx2.dir/src/modules/audio_processing/aec3/vector_math_avx2.cc.o.
d -o CMakeFiles/tg_owt_avx2.dir/src/modules/audio_processing/aec3/vector_math_avx2.cc.o -c /usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/modules/audio_processing/aec3/vector_math_avx
2.cc
In file included from /usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/modules/audio_processing/aec3/vector_math_avx2.cc:11:
In file included from /usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/modules/audio_processing/aec3/vector_math.h:29:
In file included from /usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/api/array_view.h:19:
/usr/ports/pobj/tg_owt-0.0.0.20220123/tg_owt-6372a0848f8dd84013e291b44f9d1427fde3a90e/src/rtc_base/checks.h:57:10: fatal error: 'absl/meta/type_traits.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

`find_package(absl)` does not populate `absl_INCLUDE_DIRS` so pick an
arbitrary library and use pkg-config to get its include directory,
assuming all absl libraries use have the same.

Silence the duplicate requirement and only do it if cmake found absl
already.
