### PR TITLE
Remove epoxy dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,13 +126,15 @@ if (TG_OWT_USE_PIPEWIRE)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(GBM REQUIRED gbm)
     pkg_check_modules(DRM REQUIRED libdrm)
-    pkg_check_modules(EPOXY REQUIRED epoxy)
+    pkg_check_modules(GL REQUIRED gl)
+    pkg_check_modules(EGL REQUIRED egl)
 
     target_include_directories(tg_owt SYSTEM
     PRIVATE
         ${GBM_INCLUDE_DIRS}
         ${DRM_INCLUDE_DIRS}
-        ${EPOXY_INCLUDE_DIRS}
+        ${GL_INCLUDE_DIRS}
+        ${EGL_INCLUDE_DIRS}
     )
 endif()
 

--- a/src/modules/desktop_capture/linux/egl_dmabuf.h
+++ b/src/modules/desktop_capture/linux/egl_dmabuf.h
@@ -11,8 +11,8 @@
 #ifndef MODULES_DESKTOP_CAPTURE_LINUX_EGL_DMABUF_H_
 #define MODULES_DESKTOP_CAPTURE_LINUX_EGL_DMABUF_H_
 
-#include <epoxy/egl.h>
-#include <epoxy/gl.h>
+#include <EGL/egl.h>
+#include <GL/gl.h>
 #include <gbm.h>
 
 #include <memory>


### PR DESCRIPTION
webrtc seem to manually load GL libraries with dlopen, so epoxy is actually unused