### PR TITLE
Patch: Use public/system h264 includes

### DIFF
--- a/src/modules/video_coding/codecs/h264/h264_encoder_impl.cc
+++ b/src/modules/video_coding/codecs/h264/h264_encoder_impl.cc
@@ -31,10 +31,10 @@
 #include "system_wrappers/include/metrics.h"
 #include "third_party/libyuv/include/libyuv/convert.h"
 #include "third_party/libyuv/include/libyuv/scale.h"
-#include "third_party/openh264/src/codec/api/svc/codec_api.h"
-#include "third_party/openh264/src/codec/api/svc/codec_app_def.h"
-#include "third_party/openh264/src/codec/api/svc/codec_def.h"
-#include "third_party/openh264/src/codec/api/svc/codec_ver.h"
+#include <wels/codec_api.h>
+#include <wels/codec_app_def.h>
+#include <wels/codec_def.h>
+#include <wels/codec_ver.h>
 
 namespace webrtc {
 

--- a/src/modules/video_coding/codecs/h264/h264_encoder_impl.h
+++ b/src/modules/video_coding/codecs/h264/h264_encoder_impl.h
@@ -26,7 +26,7 @@
 #include "modules/video_coding/codecs/h264/include/h264.h"
 #include "modules/video_coding/svc/scalable_video_controller.h"
 #include "modules/video_coding/utility/quality_scaler.h"
-#include "third_party/openh264/src/codec/api/svc/codec_app_def.h"
+#include <wels/codec_app_def.h>
 
 class ISVCEncoder;
 


### PR DESCRIPTION
99edacee "Update: Copy updated source files (M108+H265)." changed those
to the bundled headers, but `cmake/libopenh264.cmake` does create a
public "wels/" include directory, i.e. building with `<wels/*.h>` works
with both external/system/packages and bundled openh264 alike.

Revert the includes to unbreak the tg_owt build on OpenBSD where unused
`third_party/` content is removed to prevent accidential use like this.
