### PR TITLE
Patch: Use video(4) <sys/videoio.h> on OpenBSD

### DIFF
--- a/src/modules/video_capture/linux/device_info_v4l2.cc
+++ b/src/modules/video_capture/linux/device_info_v4l2.cc
@@ -18,7 +18,11 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 // v4l includes
+#if defined(__OpenBSD__)
+#include <sys/videoio.h>
+#else
 #include <linux/videodev2.h>
+#endif
 
 #include <vector>
 

--- a/src/modules/video_capture/linux/video_capture_v4l2.cc
+++ b/src/modules/video_capture/linux/video_capture_v4l2.cc
@@ -12,7 +12,11 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#if defined(__OpenBSD__)
+#include <sys/videoio.h>
+#else
 #include <linux/videodev2.h>
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
The other two v4l2 files already have this define, see merged
https://github.com/desktop-app/tg_owt/pull/81
```
commit 62b67d5ca6fa9e8b9f813fd7d715e0e4cf908dfb
    Patch: video_capture: Use correct V4L2 header on OpenBSD

    video(4) provides everything needed, the Linux header does not exist.
    Tested on OpenBSD/amd64 7.0 -CURRENT.
```
