### PR TITLE
Fix fcntl call.

### DIFF
--- a/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+++ b/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
@@ -433,7 +433,7 @@ bool SharedScreenCastStreamPrivate::StartScreenCastStream(
 
     if (fd >= 0) {
       pw_core_ = pw_context_connect_fd(
-          pw_context_, fcntl(fd, F_DUPFD_CLOEXEC), nullptr, 0);
+          pw_context_, fcntl(fd, F_DUPFD_CLOEXEC, 0), nullptr, 0);
     } else {
       pw_core_ = pw_context_connect(pw_context_, nullptr, 0);
     }


### PR DESCRIPTION
As per man 2 fcntl:

> fcntl() can take an optional third argument.  Whether or not this
>        argument is required is determined by cmd.  The required argument
>        type is indicated in parentheses after each cmd name (in most
>        cases, the required type is int, and we identify the argument
>        using the name arg), or void is specified if the argument is not
>        required.
> ...
> F_DUPFD_CLOEXEC (int; since Linux 2.6.24)

After this fix, screensharing starts working with wayland + pipewire.

Before it was failing due to garbage in required argument.

> strace -e fcntl telegram-desktop
> ...
> fcntl(136, F_DUPFD_CLOEXEC, 140469472426232) = -1 EINVAL (Invalid argument)