### PR TITLE
Fix screencast glitching on KDE6/wayland when moving the cursor

### DIFF
--- a/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+++ b/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
@@ -339,6 +339,16 @@ void SharedScreenCastStreamPrivate::OnStreamProcess(void* data) {
     return;
   }
 
+  struct spa_meta_header* header =
+      static_cast<spa_meta_header*>(spa_buffer_find_meta_data(
+          buffer->buffer, SPA_META_Header, sizeof(*header)));
+  if (header && (header->flags & SPA_META_HEADER_FLAG_CORRUPTED)) {
+    RTC_LOG(LS_INFO) << "Dropping corrupted buffer";
+    // Queue buffer for reuse; it will not be processed further.
+    pw_stream_queue_buffer(that->pw_stream_, buffer);
+    return;
+  }
+
   that->ProcessBuffer(buffer);
 
   pw_stream_queue_buffer(that->pw_stream_, buffer);
@@ -640,7 +650,14 @@ void SharedScreenCastStreamPrivate::ProcessBuffer(pw_buffer* buffer) {
     }
   }
 
-  if (spa_buffer->datas[0].chunk->size == 0) {
+  if (spa_buffer->datas[0].chunk->flags & SPA_CHUNK_FLAG_CORRUPTED) {
+    RTC_LOG(LS_INFO) << "Dropping buffer with corrupted or missing data";
+    return;
+  }
+
+  if (spa_buffer->datas[0].type == SPA_DATA_MemFd &&
+      spa_buffer->datas[0].chunk->size == 0) {
+    RTC_LOG(LS_INFO) << "Dropping buffer with empty data";
     return;
   }
 


### PR DESCRIPTION
The issues is observed in [telegram-desktop](https://github.com/telegramdesktop/tdesktop). The patch is taken from upstream webrtc with `observer_` related code removed since our branch does not have that.

Upstream patch: https://webrtc-review.googlesource.com/c/src/+/349881
Upstream bug: https://issues.webrtc.org/issues/338232699