### PR TITLE
Unbundle libSRTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ include(cmake/generate_field_trials.cmake)
 include(cmake/external.cmake)
 include(cmake/libpffft.cmake)
 include(cmake/librnnoise.cmake)
-include(cmake/libsrtp.cmake)
 include(cmake/libyuv.cmake)
 if (APPLE)
     include(cmake/libsdkmacos.cmake)
@@ -132,7 +131,6 @@ target_link_libraries(tg_owt
 PRIVATE
     tg_owt::libpffft
     tg_owt::librnnoise
-    tg_owt::libsrtp
     tg_owt::libyuv
 )
 
@@ -153,6 +151,7 @@ link_ffmpeg(tg_owt)
 link_opus(tg_owt)
 link_libabsl(tg_owt)
 link_libopenh264(tg_owt)
+link_libsrtp(tg_owt)
 link_libvpx(tg_owt)
 link_crc32c(tg_owt)
 link_dl(tg_owt)
@@ -2631,12 +2630,17 @@ list(APPEND export_targets
     libwebrtcbuild
     libpffft
     librnnoise
-    libsrtp
     libyuv
 )
 if (NOT absl_FOUND)
     include(cmake/libabsl.cmake)
     list(APPEND export_targets libabsl)
+endif()
+if (NOT SRTP_FOUND)
+    include(cmake/libsrtp.cmake)
+    list(APPEND export_targets libsrtp)
+else()
+    target_compile_definitions(tg_owt PRIVATE WEBRTC_EXTERNAL_SRTP)
 endif()
 if (NOT Crc32c_FOUND)
     include(cmake/libcrc32c.cmake)

--- a/cmake/external.cmake
+++ b/cmake/external.cmake
@@ -150,6 +150,21 @@ function(link_libopenh264 target_name)
     endif()
 endfunction()
 
+# libSRTP
+function(link_libsrtp target_name)
+    if (TG_OWT_PACKAGED_BUILD)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(SRTP libsrtp2)
+        if (SRTP_FOUND)
+            target_include_directories(${target_name} SYSTEM PRIVATE ${SRTP_INCLUDE_DIRS})
+            target_link_libraries(${target_name} PRIVATE ${SRTP_LINK_LIBRARIES})
+        endif()
+    endif()
+    if (NOT SRTP_FOUND)
+        target_link_libraries(${target_name} PRIVATE tg_owt::libsrtp)
+    endif()
+endfunction()
+
 # libvpx
 set(TG_OWT_LIBVPX_INCLUDE_PATH "" CACHE STRING "Include path for libvpx.")
 function(link_libvpx target_name)

--- a/src/pc/external_hmac.cc
+++ b/src/pc/external_hmac.cc
@@ -15,7 +15,6 @@
 
 #include "rtc_base/logging.h"
 #include "rtc_base/zero_memory.h"
-#include "third_party/libsrtp/include/srtp.h"
 
 // Begin test case 0 */
 static const uint8_t kExternalHmacTestCase0Key[20] = {

--- a/src/pc/external_hmac.h
+++ b/src/pc/external_hmac.h
@@ -30,9 +30,12 @@
 
 #include <stdint.h>
 
-#include "third_party/libsrtp/crypto/include/crypto_types.h"
-#include "third_party/libsrtp/include/srtp.h"
-#include "third_party/libsrtp/include/srtp_priv.h"
+#ifdef WEBRTC_EXTERNAL_SRTP
+# include <srtp2/auth.h>
+# include <srtp2/srtp.h>
+#else
+# include "srtp_priv.h"
+#endif
 
 #define EXTERNAL_HMAC_SHA1 SRTP_HMAC_SHA1 + 1
 #define HMAC_KEY_LENGTH 20

--- a/src/pc/srtp_session.cc
+++ b/src/pc/srtp_session.cc
@@ -295,6 +295,7 @@ bool SrtpSession::GetRtpAuthParams(uint8_t** key, int* key_len, int* tag_len) {
   RTC_DCHECK(thread_checker_.IsCurrent());
   RTC_DCHECK(IsExternalAuthActive());
 #ifdef WEBRTC_EXTERNAL_SRTP
+  RTC_CHECK(false);
   return false;
 #else
   if (!IsExternalAuthActive()) {
@@ -351,6 +352,7 @@ bool SrtpSession::GetSendStreamPacketIndex(void* p,
                                            int64_t* index) {
   RTC_DCHECK(thread_checker_.IsCurrent());
 #ifdef WEBRTC_EXTERNAL_SRTP
+  RTC_CHECK(false);
   return false;
 #else
   srtp_hdr_t* hdr = reinterpret_cast<srtp_hdr_t*>(p);

--- a/src/pc/srtp_session.cc
+++ b/src/pc/srtp_session.cc
@@ -30,8 +30,12 @@
 #include "rtc_base/thread_annotations.h"
 #include "rtc_base/time_utils.h"
 #include "system_wrappers/include/metrics.h"
-#include "third_party/libsrtp/include/srtp.h"
-#include "third_party/libsrtp/include/srtp_priv.h"
+
+#ifdef WEBRTC_EXTERNAL_SRTP
+# include <srtp2/srtp.h>
+#else
+# include "srtp_priv.h"
+#endif
 
 namespace cricket {
 
@@ -290,6 +294,9 @@ bool SrtpSession::UnprotectRtcp(void* p, int in_len, int* out_len) {
 bool SrtpSession::GetRtpAuthParams(uint8_t** key, int* key_len, int* tag_len) {
   RTC_DCHECK(thread_checker_.IsCurrent());
   RTC_DCHECK(IsExternalAuthActive());
+#ifdef WEBRTC_EXTERNAL_SRTP
+  return false;
+#else
   if (!IsExternalAuthActive()) {
     return false;
   }
@@ -313,6 +320,7 @@ bool SrtpSession::GetRtpAuthParams(uint8_t** key, int* key_len, int* tag_len) {
   *key_len = external_hmac->key_length;
   *tag_len = rtp_auth_tag_len_;
   return true;
+#endif
 }
 
 int SrtpSession::GetSrtpOverhead() const {
@@ -342,6 +350,9 @@ bool SrtpSession::GetSendStreamPacketIndex(void* p,
                                            int in_len,
                                            int64_t* index) {
   RTC_DCHECK(thread_checker_.IsCurrent());
+#ifdef WEBRTC_EXTERNAL_SRTP
+  return false;
+#else
   srtp_hdr_t* hdr = reinterpret_cast<srtp_hdr_t*>(p);
   srtp_stream_ctx_t* stream = srtp_get_stream(session_, hdr->ssrc);
   if (!stream) {
@@ -352,6 +363,7 @@ bool SrtpSession::GetSendStreamPacketIndex(void* p,
   *index = static_cast<int64_t>(rtc::NetworkToHost64(
       srtp_rdbx_get_packet_index(&stream->rtp_rdbx) << 16));
   return true;
+#endif
 }
 
 bool SrtpSession::DoSetKey(int type,


### PR DESCRIPTION
Avoid private symbols and link against system-wide libSRTP. The excluded code in SrtpSession looks unreachable from the call integration in Telegram Desktop.

Rebased version of #123 where the author blocked tg_owt developers, thus hindering progress...

OpenBSD has used this PR since inception, no complaints/problems with audio/video calls so far using liibSRTP 2.6.0.