### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/modules/video_capture/video_capture_options.h
+++ b/src/modules/video_capture/video_capture_options.h
@@ -55,7 +55,7 @@ class RTC_EXPORT VideoCaptureOptions {
 
   void Init(Callback* callback);
 
-#if defined(WEBRTC_LINUX)
+#if (defined(WEBRTC_LINUX) || defined(WEBRTC_FREEBSD))
   bool allow_v4l2() const { return allow_v4l2_; }
   void set_allow_v4l2(bool allow) { allow_v4l2_ = allow; }
 #endif
@@ -68,7 +68,7 @@ class RTC_EXPORT VideoCaptureOptions {
 #endif
 
  private:
-#if defined(WEBRTC_LINUX)
+#if (defined(WEBRTC_LINUX) || defined(WEBRTC_FREEBSD))
   bool allow_v4l2_ = false;
 #endif
 #if defined(WEBRTC_USE_PIPEWIRE)


### PR DESCRIPTION
```
FAILED: CMakeFiles/tg_owt.dir/src/modules/video_capture/linux/video_capture_linux.cc.o
/usr/bin/c++ -DABSL_ALLOCATOR_NOTHROW=1 -DBWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0 -DHAVE_LIBSRTP -DHAVE_NETINET_IN_H -DHAVE_SCTP -DHAVE_WEBRTC_VIDEO -DNDEBUG -DNO_MAIN_THREAD_WRAPPING -DRTC_DISABLE_TRACE_EVENTS -DRTC_ENABLE_H265 -DRTC_ENABLE_VP9 -DWEBRTC_APM_DEBUG_DUMP=0 -DWEBRTC_DUMMY_AUDIO_BUILD -DWEBRTC_ENABLE_PROTOBUF=0 -DWEBRTC_FREEBSD -DWEBRTC_HAVE_DCSCTP -DWEBRTC_HAVE_SCTP -DWEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE -DWEBRTC_LIBRARY_IMPL -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=1 -DWEBRTC_OPUS_SUPPORT_120MS_PTIME=1 -DWEBRTC_OPUS_VARIABLE_COMPLEXITY=0 -DWEBRTC_POSIX -DWEBRTC_USE_BUILTIN_ISAC_FLOAT -DWEBRTC_USE_H264 -DWEBRTC_USE_PIPEWIRE -DWEBRTC_USE_X11 -I/usr/local/poudriere/ports/local/net-im/tg_owt/work/.build/gen -I/usr/local/poudriere/ports/local/net-im/tg_owt/work/tg_owt-e9d103e/src -I/usr/local/poudriere/ports/local/net-im/tg_owt/work/tg_owt-e9d103e/src/third_party/pffft/src -I/usr/local/poudriere/ports/local/net-im/tg_owt/work/tg_owt-e9d103e/src/third_party/libyuv/include -isystem /usr/local/include/gio-unix-2.0 -isystem /usr/local/include -isystem /usr/local/include/glib-2.0 -isystem /usr/local/lib/glib-2.0/include -isystem /usr/local/include/pipewire-0.3 -isystem /usr/local/include/spa-0.2 -isystem /usr/local/include/libdrm -isystem /usr/local/include/opus -O2 -pipe -fstack-protector-strong -fno-strict-aliasing -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -DNDEBUG -std=gnu++20 -Wno-deprecated-declarations -Wno-attributes -Wno-narrowing -Wno-return-type -pthread -MD -MT CMakeFiles/tg_owt.dir/src/modules/video_capture/linux/video_capture_linux.cc.o -MF CMakeFiles/tg_owt.dir/src/modules/video_capture/linux/video_capture_linux.cc.o.d -o CMakeFiles/tg_owt.dir/src/modules/video_capture/linux/video_capture_linux.cc.o -c /usr/local/poudriere/ports/local/net-im/tg_owt/work/tg_owt-e9d103e/src/modules/video_capture/linux/video_capture_linux.cc
/usr/local/poudriere/ports/local/net-im/tg_owt/work/tg_owt-e9d103e/src/modules/video_capture/linux/video_capture_linux.cc:63:16: error: no member named 'allow_v4l2' in 'webrtc::VideoCaptureOptions'
   63 |   if (options->allow_v4l2()) {
      |       ~~~~~~~  ^
1 error generated.
```