### PR TITLE
Fix V4L2 build in WebRTC for BSDs

### DIFF
--- a/src/modules/video_capture/video_capture_options.h
+++ b/src/modules/video_capture/video_capture_options.h
@@ -55,7 +55,7 @@ class RTC_EXPORT VideoCaptureOptions {
 
   void Init(Callback* callback);
 
-#if defined(WEBRTC_LINUX)
+#if defined(WEBRTC_POSIX) && !defined(WEBRTC_APPLE)
   bool allow_v4l2() const { return allow_v4l2_; }
   void set_allow_v4l2(bool allow) { allow_v4l2_ = allow; }
 #endif
@@ -68,7 +68,7 @@ class RTC_EXPORT VideoCaptureOptions {
 #endif
 
  private:
-#if defined(WEBRTC_LINUX)
+#if defined(WEBRTC_POSIX) && !defined(WEBRTC_APPLE)
   bool allow_v4l2_ = false;
 #endif
 #if defined(WEBRTC_USE_PIPEWIRE)


### PR DESCRIPTION
Despite the name, Video-for-Linux is used on OpenBSD and FreeBSD as well.

As per `cmake/libwebrtcbuild.cmake`, all supported UNIX systems except Apple.

Fixes this:
```
.../src/modules/video_capture/linux/video_capture_linux.cc:63:16: error: no member named 'allow_v4l2' in 'webrtc::VideoCaptureOptions'
  if (options->allow_v4l2()) {
      ~~~~~~~  ^
1 error generated.
```