### PR TITLE
Skip all PipeWire files under TG_OWT_USE_PIPEWIRE:BOOL=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2445,6 +2445,15 @@ if (NOT TG_OWT_USE_PIPEWIRE)
         modules/desktop_capture/linux/wayland/xdg_desktop_portal_utils.h
         modules/desktop_capture/linux/wayland/xdg_session_details.h
 
+        modules/video_capture/linux/camera_portal.cc
+        modules/video_capture/linux/camera_portal.h
+        modules/video_capture/linux/device_info_pipewire.cc
+        modules/video_capture/linux/device_info_pipewire.h
+        modules/video_capture/linux/pipewire_session.cc
+        modules/video_capture/linux/pipewire_session.h
+        modules/video_capture/linux/video_capture_pipewire.cc
+        modules/video_capture/linux/video_capture_pipewire.h
+
         modules/portal/pipewire.sigs
         modules/portal/pipewire_stub_header.fragment
         modules/portal/pipewire_utils.cc


### PR DESCRIPTION
Fixes OpenBSD's build:
```
.../src/modules/video_capture/linux/pipewire_session.h:14:10: fatal error: 'pipewire/core.h' file not found
```

glib-2.0 is only ever a transitive dependency for PipeWire:
```
.../src/modules/video_capture/linux/camera_portal.cc:13:10: fatal error: 'gio/gio.h' file not found
```