### PR TITLE
reorder_optimizer.cc: add include for int64_t

### DIFF
--- a/src/modules/audio_coding/neteq/reorder_optimizer.cc
+++ b/src/modules/audio_coding/neteq/reorder_optimizer.cc
@@ -11,6 +11,7 @@
 #include "modules/audio_coding/neteq/reorder_optimizer.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <vector>
 


### PR DESCRIPTION
Required when using musl libc, for example.