### PR TITLE
Fix mismatching pipewire types

### DIFF
--- a/src/modules/video_capture/linux/pipewire_session.cc
+++ b/src/modules/video_capture/linux/pipewire_session.cc
@@ -60,7 +60,7 @@ PipeWireNode::PipeWireNode(PipeWireSession* session,
       .param = OnNodeParam,
   };
 
-  pw_node_add_listener(proxy_, &node_listener_, &node_events, this);
+  pw_node_add_listener(reinterpret_cast<struct pw_node*>(proxy_), &node_listener_, &node_events, this);
 }
 
 PipeWireNode::~PipeWireNode() {
@@ -94,7 +94,7 @@ void PipeWireNode::OnNodeInfo(void* data, const pw_node_info* info) {
       uint32_t id = info->params[i].id;
       if (id == SPA_PARAM_EnumFormat &&
           info->params[i].flags & SPA_PARAM_INFO_READ) {
-        pw_node_enum_params(that->proxy_, 0, id, 0, UINT32_MAX, nullptr);
+        pw_node_enum_params(reinterpret_cast<struct pw_node*>(that->proxy_), 0, id, 0, UINT32_MAX, nullptr);
         break;
       }
     }


### PR DESCRIPTION
Fixes #148.
Caused by https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/188d920733f0791413d3386e5536ee7377f71b2f.