### PR TITLE
reorder_optimizer.cc: add missing include

### DIFF
--- a/src/modules/audio_coding/neteq/reorder_optimizer.cc
+++ b/src/modules/audio_coding/neteq/reorder_optimizer.cc
@@ -11,6 +11,7 @@
 #include "modules/audio_coding/neteq/reorder_optimizer.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 #include <vector>
 


### PR DESCRIPTION
The use of `int64_t` below requires this include, on some libcs.