### PR TITLE
CMake: Don't use REQUIRED with find_dependency

### DIFF
--- a/cmake/tg_owtConfig.cmake
+++ b/cmake/tg_owtConfig.cmake
@@ -1,9 +1,9 @@
 include(CMakeFindDependencyMacro)
 if (@absl_FOUND@)
-    find_dependency(absl REQUIRED)
+    find_dependency(absl)
 endif()
 if (@Crc32c_FOUND@)
-    find_dependency(Crc32c REQUIRED)
+    find_dependency(Crc32c)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/tg_owtTargets.cmake")


### PR DESCRIPTION
It stops the execution of config file by default while with REQUIRED it stops execution of the entire cmake configuration