### PR TITLE
Remove ABSL_ATTRIBUTE_LIFETIME_BOUND from void functions

### DIFF
--- a/src/api/candidate.h
+++ b/src/api/candidate.h
@@ -105,7 +105,7 @@ class RTC_EXPORT Candidate {
   // cricket::LOCAL_PORT_TYPE). The type should really be an enum rather than a
   // string, but until we make that change the lifetime attribute helps us lock
   // things down. See also the `Port` class.
-  void set_type(absl::string_view type ABSL_ATTRIBUTE_LIFETIME_BOUND) {
+  void set_type(absl::string_view type) {
     Assign(type_, type);
   }
 


### PR DESCRIPTION
LLVM 20 errors on void functions whose parameters are applied
[[lifetimebound]].

Link: https://github.com/llvm/llvm-project/pull/113460
