### PR TITLE
Build with OpenSSL 4 (ASN1_STRING became opaque)

### DIFF
--- a/src/rtc_base/openssl_certificate.cc
+++ b/src/rtc_base/openssl_certificate.cc
@@ -275,16 +275,18 @@ bool OpenSSLCertificate::operator!=(const OpenSSLCertificate& other) const {
 }
 
 int64_t OpenSSLCertificate::CertificateExpirationTime() const {
-  ASN1_TIME* expire_time = X509_get_notAfter(x509_);
+  const ASN1_TIME* expire_time = X509_get0_notAfter(x509_);
   bool long_format;
-  if (expire_time->type == V_ASN1_UTCTIME) {
+  const int time_type = ASN1_STRING_type(expire_time);
+  if (time_type == V_ASN1_UTCTIME) {
     long_format = false;
-  } else if (expire_time->type == V_ASN1_GENERALIZEDTIME) {
+  } else if (time_type == V_ASN1_GENERALIZEDTIME) {
     long_format = true;
   } else {
     return -1;
   }
-  return ASN1TimeToSec(expire_time->data, expire_time->length, long_format);
+  return ASN1TimeToSec(ASN1_STRING_get0_data(expire_time),
+                       ASN1_STRING_length(expire_time), long_format);
 }
 
 }  // namespace rtc


### PR DESCRIPTION
OpenSSL 4.0 made the ASN1_STRING struct opaque -- and ASN1_TIME is an alias of
asn1_string_st -- so its fields can no longer be accessed directly. This:

    ASN1_TIME* expire_time = X509_get_notAfter(x509_);
    if (expire_time->type == V_ASN1_UTCTIME) ...
    return ASN1TimeToSec(expire_time->data, expire_time->length, long_format);

fails with "invalid use of incomplete type 'ASN1_TIME' {aka struct
asn1_string_st}" and tg_owt does not build against OpenSSL 4.

Direct field access is replaced with the equivalent public accessors:

    ->type    ->  ASN1_STRING_type()
    ->data    ->  ASN1_STRING_get0_data()
    ->length  ->  ASN1_STRING_length()

and X509_get_notAfter() with X509_get0_notAfter(), which returns a
const ASN1_TIME* -- the appropriate choice here, since the value is only read.

Backwards compatible: all three accessors and X509_get0_notAfter have existed
since OpenSSL 1.1.0, so the same code keeps building against 1.1, 3.x and 4.x.
No version #if is needed.

This is the same fix Qt applied in "Update sources to support OpenSSL 4"
(qt/qtbase e806630e694d), whose message notes: "ASN1_STRING was made opaque in
OpenSSL 4, so replace direct access with use of accessor functions through the
wrappers".

Only openssl_certificate.cc is touched: boringssl_certificate.cc has the same
pattern but is not compiled in an OpenSSL build (0 occurrences in build.ninja).
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
